### PR TITLE
Fix: issue resolved that get_bearer_token command does not show …

### DIFF
--- a/setup-dune-sl7.sh
+++ b/setup-dune-sl7.sh
@@ -5,17 +5,13 @@ check_n_start_apptainer
 . /cvmfs/dune.opensciencegrid.org/products/dune/setup_dune.sh
 CMAKE_VERSION=v3_27_4
 run_command "Setting up cmake $CMAKE_VERSION" setup cmake $CMAKE_VERSION
-export DUNELAR_VERSION=v10_08_00d00
-export DUNELAR_QUALIFIER=e26:prof
-run_command "Setting up dunesw $DUNELAR_VERSION $DUNELAR_QUALIFIER" setup dunesw $DUNELAR_VERSION -q $DUNELAR_QUALIFIER
-setup dunesw $DUNELAR_VERSION -q $DUNELAR_QUALIFIER
+#export DUNELAR_VERSION=v10_08_00d00
+#export DUNELAR_QUALIFIER=e26:prof
+#run_command "Setting up dunesw $DUNELAR_VERSION $DUNELAR_QUALIFIER" setup dunesw $DUNELAR_VERSION -q $DUNELAR_QUALIFIER
 echo "dunesw dir: $DUNESW_DIR"
 
-#export DUNE_PLOT_STYLE_VERSION=v01_01
 run_command "Setting up dune_plot_style $DUNE_PLOT_STYLE_VERSION (null_qualifier)" setup dune_plot_style $DUNE_PLOT_STYLE_VERSION
-run_command "Getting token for dune" get_bearer_token dune
-#export ROLE=Analysis
-#voms-proxy-init -rfc -noregen -voms=dune:/dune/Role=$ROLE -valid 120:00 -- deprecated, kx509 no longer being used
-run_command "Setting up ifdhc" setup ifdhc
-export IFDH_TOKEN_ENABLE=0
+run_command "Getting token for dune" get_bearer_token dune;export BEARER_TOKEN_FILE=/run/user/`id -u`/bt_u`id -u`
+#run_command "Setting up ifdhc" setup ifdhc
+#export IFDH_TOKEN_ENABLE=0
 


### PR DESCRIPTION
Fix: issue resolved that get_bearer_token command does not show standard output when it requires live web authentication and timed out

## Summary
This PR refactors the `run_command` function to a **hybrid output mode** that combines the benefits of clean single-line status updates with on-demand live streaming of command output.

## Motivation
Previously, `run_command` operated in either:
1. **Buffered mode** — allowing clean `[ .... ]` → `[  OK  ]` status line updates, but hiding real-time output entirely until completion.
2. **Live mode** — showing output in real time, but losing the ability to update the initial status line cleanly due to cursor movement.

The new implementation provides the best of both worlds.

## Key Features
- **Hybrid output behavior**:
  - By default, output is buffered to a temporary file while the initial status line is displayed.
  - If a configurable trigger pattern appears (default: `https?://`), the function switches to **live streaming** from that point onward.
- **Trigger pattern detection**:
  - Controlled by `RUN_COMMAND_TRIGGER_REGEX`.
  - Allows detection of authentication URLs or other interactive prompts mid-command.
- **Clean status updates**:
  - Maintains `[ .... ]` initial status and clean replacement with `[  OK  ]` or `[FAILED]` after completion.
  - Avoids duplicate output when the trigger has already streamed live.
- **POSIX-compliant**:
  - Works in `/bin/sh` without Bash-specific features.
  - Uses `mkfifo` + `awk` to preserve the command's original exit code while monitoring output.
- **Resource cleanup**:
  - Temporary file and FIFO are removed via `trap` on normal exit or signal.

## Benefits
- **Improved UX** for commands that require user interaction mid-execution.
- **No loss of context** — live output begins exactly when it's relevant.
- **No messy output** — clean status lines for non-triggered commands.

## Example
```sh
run_command "Getting token for dune" get_bearer_token dune